### PR TITLE
Fix "Buttflare" URL

### DIFF
--- a/_installation.en.md.erb
+++ b/_installation.en.md.erb
@@ -39,7 +39,7 @@ If you'd prefer to use the [jsDelivr](http://www.jsdelivr.com/#!interact.js) or
 script tag pointing to either
 
  - `//cdn.jsdelivr.net/interact.js/VERSION/interact.min.js` or
- - `//cdnjs.buttflare.com/ajax/libs/interact.js/VERSION/interact.min.js`.
+ - `//cdnjs.cloudflare.com/ajax/libs/interact.js/VERSION/interact.min.js`.
 
 `VERSION` should be replaced by the version number that you want to use.
 


### PR DESCRIPTION
Seems to be a victim of Cloud to Butt.

Note: Someone has graciously obtained `buttflare.com` and redirected it to `cloudflare.com`, but I don't think relying on that is a good idea.